### PR TITLE
Http-Only Cookies

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, HttpCode, HttpStatus, Post, Body, HttpException, UseGuards, Get, Request, Res} from '@nestjs/common';
+import { Controller, HttpCode, HttpStatus, Post, Body, UseGuards, Get, Request, Res} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthGuard } from './auth.guard';
 import { Response } from 'express';
@@ -29,24 +29,26 @@ export class AuthController {
         }
         catch (error) {
             console.log(error);
-            throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+            response.status(HttpStatus.BAD_REQUEST).send(error.message);
         }
     }
 
     @HttpCode(HttpStatus.CREATED)
     @Post('signup')
-    async signUp(@Body() signInDto: SignUpDto): Promise<{access_token: string} | {error: string}> {
+    async signUp(@Body() signInDto: SignUpDto, @Res({passthrough: true}) response: Response): Promise<void> {
         try {
             const { username, email, password } = signInDto;
-            console.log(username, email, password);
-            return this.authService.signUp(username, email, password);
+            const { access_token } = await this.authService.signUp(username, email, password);
+            response.cookie('wd_access_token', access_token, {httpOnly: true, secure: true});
+            response.send();
         }
         catch (error) {
             console.log(error);
-            throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+            response.status(HttpStatus.BAD_REQUEST).send(error.message);
         }
     }
 
+    // used for easily testing the auth guard, will be removed later
     @UseGuards(AuthGuard)
     @Get('profile')
     async getProfile(@Request() req): Promise<any> {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, HttpCode, HttpStatus, Post, Body, HttpException, UseGuards, Get, Request} from '@nestjs/common';
+import { Controller, HttpCode, HttpStatus, Post, Body, HttpException, UseGuards, Get, Request, Res} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthGuard } from './auth.guard';
+import { Response } from 'express';
 
 class SignInDto {
     username: string;
@@ -19,10 +20,12 @@ export class AuthController {
     
     @HttpCode(HttpStatus.OK)
     @Post('signin')
-    async login(@Body() signInDto: SignInDto): Promise<{access_token: string}> {
+    async login(@Body() signInDto: SignInDto, @Res({passthrough: true}) response: Response): Promise<void> {
         try {
             const { username, password } = signInDto;
-            return this.authService.signIn(username, password);
+            const { access_token } = await this.authService.signIn(username, password);
+            response.cookie('wd_access_token', access_token, {httpOnly: true, secure: true});
+            response.send();
         }
         catch (error) {
             console.log(error);

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -1,8 +1,6 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
-import { Observable } from 'rxjs';
 import { JwtService } from '@nestjs/jwt';
 import { jwtConstants } from './constants';
-import { Request } from 'express';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -25,8 +23,16 @@ export class AuthGuard implements CanActivate {
         return true;
     }
 
-    async extractToken(request: Request): Promise<string | undefined> {
-        const [type, token] = request.headers.authorization?.split(' ') ?? [];
-        return type === 'Bearer' ? token : undefined;
+    async extractToken(request: any): Promise<string | undefined> {
+        const cookies: string = request.headers.cookie;
+        if (!cookies) {
+            return undefined;
+        }
+        const tokenCookie = cookies.split(';').find(c => c.trim().startsWith('wd_access_token='));
+        if (!tokenCookie) {
+            return undefined;
+        }
+        const token = tokenCookie.split('=')[1];
+        return token;
     }
 }

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,4 +1,4 @@
 export const jwtConstants = {
-    secret: 'TODO: Change Me',
-    expiresIn: '360s'
+    secret: 'TODO: change me and secure me in a safe place',
+    expiresIn: '6h'
 };

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -31,7 +31,6 @@ export class UserService {
     }
 
     async getAllIDs(): Promise<string[]> {
-        console.log(`SELECT ${UserService.id} FROM ${UserService.table}`);
         const data = await this.postgresService.query(`SELECT ${UserService.id} FROM ${UserService.table}`);
         return data.rows;
     }
@@ -49,7 +48,7 @@ export class UserService {
     async createUser(username: string, email: string, password: string): Promise<User> {
         const id = await this.createID();
         const data = await this.postgresService.query(`INSERT INTO ${UserService.table} (${UserService.id}, ${UserService.username}, ${UserService.email}, ${UserService.password}) VALUES ('${id}', '${username}', '${email}', '${password}') RETURNING *`);
-        return data.rows;
+        return data.rows[0];
     }
 
     async createID(): Promise<string> {


### PR DESCRIPTION
Finally closes #2 

## What are we doing in this PR?

We were planning on sending JWT access tokens to client side and storing locally, but as it turns out, although the idea is still the same, we can store the token as an `http-only cookie` while sending a response back from server to client.

Many forums says it's the most secure way to store a value locally. Also, now we do not have to pass any `Bearer` token, the cookies are sent with out request automatically and we can extract them in the `AuthGuard` easily.

## Notes

You can use localhost:3000/api to use swagger, create a user or log in with a randomly added user in the database.

After you sign in or sign up, the JWT is automatically stored, and then if you send a GET request to `auth/profile`, you can directly see you username and ID