### PR TITLE
Setting Cookie Expiry for Access Tokens

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Controller, HttpCode, HttpStatus, Post, Body, UseGuards, Get, Res } fro
 import { AuthService } from './auth.service';
 import { AuthGuard } from './auth.guard';
 import { Response } from 'express';
+import { cookieOptions } from './constants';
 
 class LogInDto {
   username: string;
@@ -24,7 +25,7 @@ export class AuthController {
     try {
       const { username, password } = logInDto;
       const { access_token } = await this.authService.logIn(username, password);
-      response.cookie('wd_access_token', access_token, {httpOnly: true, secure: true});
+      response.cookie('wd_access_token', access_token, cookieOptions);
       response.send();
     }
     catch (error) {
@@ -39,7 +40,7 @@ export class AuthController {
     try {
       const { username, email, password } = signInDto;
       const { access_token } = await this.authService.signUp(username, email, password);
-      response.cookie('wd_access_token', access_token, {httpOnly: true, secure: true});
+      response.cookie('wd_access_token', access_token, cookieOptions);
       response.send();
     }
     catch (error) {

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,4 +1,13 @@
+import { CookieOptions } from "express";
+
 export const jwtConstants = {
   secret: 'TODO: change me and secure me in a safe place',
   expiresIn: '6h'
+};
+
+export const cookieOptions: CookieOptions = {
+  httpOnly: true,
+  secure: true,
+  priority: "high",
+  maxAge: 21600000
 };

--- a/wiki/auth.md
+++ b/wiki/auth.md
@@ -1,0 +1,3 @@
+Important things to keep in my mind while working in the Auth Module.
+
+**Constants:** Constant values in the `auth/constants.ts` are always manually updated. If `jwtConstants.expiresIn` is changed, then the same value should be updated in the `cookieOptions.maxAge`. 


### PR DESCRIPTION
Addition to #2 

## Explanation of the contents of the PR

Everything is cool, but we forgot to add expiry date to the http cookies, therefore they were treated as session-only cookies, which would be deleted after the web session is over. Now we are putting the CookieAge in the `constants.ts` accordin to the `jwtConstants.expiresIn` value and passing in the CookieOptions while setting the cookie.


## Notes

While changing one of the values in `jwtConstant` or `cookieOptions`, we need to change both manually, since they are constants, I find it unnecessary to be related and computed if one of them changes.